### PR TITLE
Pass pylint 2.2 checks

### DIFF
--- a/pylib/components.py
+++ b/pylib/components.py
@@ -48,7 +48,6 @@ _REQUIRED_DOC_SECTIONS = ['doc_header', 'doc_concepts', 'doc_api',
 
 class _SchemaFormatError(RuntimeError):
     """To be raised when a component configuration schema violates assumptions or conventions."""
-    pass
 
 
 def _merge_schema_entries(left, right, path=''):
@@ -384,9 +383,8 @@ def _sort_by_dependencies(nodes, ignore_cyclic_dependencies=False):
                 if todo_required.issubset(all_provided):
                     yield from todo
                     return
-                else:
-                    msg = 'The nodes {} have the unresolvable dependencies {}.'.format(todo,
-                                                                                       todo_required - all_provided)
+                msg = 'The nodes {} have the unresolvable dependencies {}.'.format(todo,
+                                                                                   todo_required - all_provided)
             else:
                 msg = 'The dependencies of the nodes {} cannot be resolved.'.format(todo)
             raise _UnresolvableDependencyError(msg)

--- a/pylib/tests.py
+++ b/pylib/tests.py
@@ -239,17 +239,16 @@ def _run_pylint_on_paths(file_paths):
     from pylint.lint import Run
     from pylint.__pkginfo__ import numversion, version
 
-    if numversion[:2] != (1, 8):
+    if numversion[:2] != (2, 2):
         print('WARNING: '
-              'The supported version of pylint is 1.8. '
+              'The supported version of pylint is 2.2. '
               'The locally installed version of pylint is ' + version + '. '
               'It may report unexpected style violations.')
 
     if not isinstance(file_paths, list):
         file_paths = list(file_paths)
 
-    runner = Run(['--rcfile=' + base_path('.pylintrc'), '-j', str(_get_number_of_cpus())] + file_paths,
-                 exit=False)
+    runner = Run(['--rcfile=' + base_path('.pylintrc'), '-j', str(_get_number_of_cpus())] + file_paths)
     if len(file_paths) == 1 and runner.linter.msg_status != 0:
         print(os.path.relpath(file_paths[0], get_top_dir()) + "\n")
 

--- a/pylib/utils.py
+++ b/pylib/utils.py
@@ -144,8 +144,7 @@ def find_path(path, topdir):
     paths = list(base_to_top_paths(topdir, path))
     if paths:
         return paths[-1]
-    else:
-        raise IOError("Unable to find the relative path '{}' in the repository hierarchy".format(path))
+    raise IOError("Unable to find the relative path '{}' in the repository hierarchy".format(path))
 
 
 def un_base_path(path):
@@ -206,12 +205,11 @@ def walk(path, flt=None):
 def get_host_platform_name():
     if sys.platform == 'darwin':
         return 'x86_64-apple-darwin'
-    elif sys.platform == 'linux':
+    if sys.platform == 'linux':
         return 'x86_64-unknown-linux-gnu'
-    elif sys.platform == 'win32':
+    if sys.platform == 'win32':
         return 'win32'
-    else:
-        raise RuntimeError('Unsupported platform {}'.format(sys.platform))
+    raise RuntimeError('Unsupported platform {}'.format(sys.platform))
 
 
 _EXECUTABLE_EXTENSION = None

--- a/release_cfg.py
+++ b/release_cfg.py
@@ -17,7 +17,7 @@ class Standard(Release):
     packages = ['armv7m', 'generic', 'rtos-example', 'machine-qemu-simple', 'machine-stm32f4-discovery',
                 'machine-armv7m-common']
     platforms = ['x86_64-apple-darwin', 'x86_64-unknown-linux-gnu']
-    version = '3.0.5'
+    version = '3.0.6'
     product_name = 'eChronos'
     release_name = 'std'
     enabled = True

--- a/test_setup.bat
+++ b/test_setup.bat
@@ -23,7 +23,7 @@ IF %ERRORLEVEL% NEQ 0 (
 )
 
 REM Install pylint because `x.py test style` depends on it
-%PYTHON% -m pip install --user --upgrade "pylint<2"
+%PYTHON% -m pip install --user --upgrade "pylint==2.2"
 
 IF NOT EXIST C:\splint-3.1.2 (
     powershell.exe -nologo -noprofile -command "& { Invoke-WebRequest 'https://raw.githubusercontent.com/wiki/echronos/echronos/splint-3.1.2.win32.zip' -OutFile 'splint-3.1.2.win32.zip'; Add-Type -A 'System.IO.Compression.FileSystem'; [IO.Compression.ZipFile]::ExtractToDirectory('splint-3.1.2.win32.zip', 'C:\'); }" || EXIT /B %ERRORLEVEL%

--- a/test_setup.sh
+++ b/test_setup.sh
@@ -82,7 +82,7 @@ then
     python${PY_VER} -m pip --version
 fi
 
-python${PY_VER} -m pip install --user "pylint<2"
+python${PY_VER} -m pip install --user "pylint==2.2"
 
 # install GDB with PowerPC support from source; required by x.py test systems
 # unpack gdb tar ball to home directory to prevent tests below from discovering and failing on unrelated files

--- a/unit_tests/sched.py
+++ b/unit_tests/sched.py
@@ -229,9 +229,8 @@ class PrioInheritSchedModel(BaseSchedModel):
                 assert blocked_on not in seen
                 if blocked_on in (task_id, None):
                     return blocked_on
-                else:
-                    seen.add(task_id)
-                    task_id = blocked_on
+                seen.add(task_id)
+                task_id = blocked_on
             return None
 
         return head(task_id for
@@ -251,11 +250,10 @@ class PrioInheritSchedModel(BaseSchedModel):
                 blocked_on = blocked_list[task_id]
                 if blocked_on in seen:
                     return False
-                elif blocked_on in (task_id, None):
+                if blocked_on in (task_id, None):
                     return True
-                else:
-                    seen.add(task_id)
-                    task_id = blocked_on
+                seen.add(task_id)
+                task_id = blocked_on
             return False
 
         def check_blocked_list(blocked_list):

--- a/x_test.py
+++ b/x_test.py
@@ -19,7 +19,6 @@ from pylib.components import _sort_typedefs, _sort_by_dependencies, _DependencyN
 class TestCase(unittest.TestCase):
     def test_empty(self):
         """Test whether an empty test can be run at all given the test setup in x.py."""
-        pass
 
     def test_sort_typedefs(self):
         typedefs = ['typedef uint8_t foo;',


### PR DESCRIPTION
# Motivation

Currently, the code style tests fail because newer version of pylint report new code style violations that haven't been addressed yet.
This is directly visible in the Travis CI and AppVeyor test results.

# Goals

The goal of this task is to ensure that the code style tests pass again.
To this end, the code base shall be updated such that the most recent version of pylint does not report code style violations.

# Release Impact: Patch

# Test Plan

- please review the code changes and ensure that they achieve the goals of this task and meet project conventions
- please ensure that the Travis CI and Appveyor regression tests still pass