### PR TITLE
Test on ubuntu 16.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ cache:
   - "${HOME}/local"
 # build matrix across multiple Python version to parallelize builds with different Python versions
 env:
-  - PY_VER=3.4
   - PY_VER=3.5
   - PY_VER=3.6
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@
 language: c
 # make full Ubuntu VM instead of just a container available, required for Python >= 3.4
 sudo: required
-# make Ubuntu trusty available, required for Python >= 3.4
-dist: trusty
+# use Ubuntu 16.04 (xenial) because it (currently) is the most recent available Ubuntu version
+dist: xenial
 # cache GDB builds
 cache:
   directories:

--- a/pylib/tests.py
+++ b/pylib/tests.py
@@ -478,6 +478,7 @@ class GdbTestCase(unittest.TestCase):
                             re.compile('( <__register_frame_info\+[0-9a-f]+>)'),
                             re.compile('=(0x[0-9a-f]+)'),
                             re.compile('Inferior( [0-9]+ )\[process( [0-9]+\]) will be killed'),
+                            re.compile('Inferior [0-9]+ \[Remote target\] will be (killed|detached)'),
                             re.compile('^([0-9]+\t.+)$'),
                             re.compile('^entry \(\) at (.+)$'),
                             re.compile('^(Thread [0-9]+ "[^"]+" hit )'),

--- a/test.sh
+++ b/test.sh
@@ -66,6 +66,7 @@ test_gen_test_systems () {
     FAILS=0
     for PKG in ${TEST_PACKAGES}
     do
+        echo ${PKG}
         python${PY_VER} "${CORE_DIR}/prj/app/prj.py" gen ${PKG} && PASSES=$((${PASSES}+1)) || FAILS=$((${FAILS}+1))
     done
     [ ${PASSES} -gt 0 ] && [ ${FAILS} -eq 0 ]
@@ -77,6 +78,7 @@ test_build_test_systems () {
     FAILS=0
     for PKG in ${TEST_PACKAGES}
     do
+        echo ${PKG}
         python${PY_VER} "${CORE_DIR}/prj/app/prj.py" build ${PKG} && PASSES=$((${PASSES}+1)) || FAILS=$((${FAILS}+1))
     done
     [ ${PASSES} -gt 0 ] && [ ${FAILS} -eq 0 ]
@@ -91,6 +93,7 @@ test_analyze_test_systems () {
         PREFIX="${PKG%%.*}"
         if test "${PREFIX}" = "stub"
         then
+            echo ${PKG}
             python${PY_VER} "${CORE_DIR}/prj/app/prj.py" analyze ${PKG} && PASSES=$((${PASSES}+1)) || FAILS=$((${FAILS}+1))
         fi
     done

--- a/test_setup.sh
+++ b/test_setup.sh
@@ -46,7 +46,6 @@ fi
 # texinfo: required for installing gdb from source
 # xvfb pandoc wkhtmltopdf: required for building documentation
 # python3.5, python3.6: currently not available in default Travis CI environment
-sudo add-apt-repository -y ppa:jonathonf/python-3.5
 sudo add-apt-repository -y ppa:jonathonf/python-3.6
 sudo apt-get -qq update
 sudo apt-get -qq install -y build-essential python3 splint gcc gdb gcc-arm-none-eabi gcc-powerpc-linux-gnu qemu-system-ppc texinfo xvfb pandoc wkhtmltopdf

--- a/test_setup.sh
+++ b/test_setup.sh
@@ -98,15 +98,3 @@ then
     make -s > make.log 2>&1 || { cat make.log; false; }
     make -s install > make.log 2>&1 || { cat make.log; false; }
 fi
-
-# The x tests depend on the master branch to exist in the git repository.
-# Travis clones the git repository in such a way that the master branch is not available.
-# Make it available:
-cd "${TRAVIS_BUILD_DIR}"
-if ! grep -e "fetch.*master" .git/config && ! grep -e "heads/\*" .git/config
-then
-    git config --add remote.origin.fetch "+refs/heads/master:refs/remotes/origin/master"
-    git fetch --depth=1
-    git branch --track master origin/master
-fi
-cd -

--- a/test_setup.sh
+++ b/test_setup.sh
@@ -49,7 +49,7 @@ fi
 sudo apt-get -qq install software-properties-common
 sudo add-apt-repository -y ppa:jonathonf/python-3.6
 sudo apt-get -qq update
-sudo apt-get -qq install -y build-essential python3 splint gcc gdb gcc-arm-none-eabi gcc-powerpc-linux-gnu qemu-system-ppc texinfo xvfb pandoc wkhtmltopdf wget
+sudo apt-get -qq install -y build-essential python3 splint gcc gdb gcc-arm-none-eabi gcc-powerpc-linux-gnu qemu-system-ppc texinfo xvfb pandoc wkhtmltopdf wget libc6-dev-powerpc-cross
 
 if ! python${PY_VER} --version; then
     sudo apt-get install -y python${PY_VER}

--- a/test_setup.sh
+++ b/test_setup.sh
@@ -49,7 +49,7 @@ fi
 sudo apt-get -qq install software-properties-common
 sudo add-apt-repository -y ppa:jonathonf/python-3.6
 sudo apt-get -qq update
-sudo apt-get -qq install -y build-essential python3 splint gcc gdb gcc-arm-none-eabi gcc-powerpc-linux-gnu qemu-system-ppc texinfo xvfb pandoc wkhtmltopdf wget libc6-dev-powerpc-cross
+sudo apt-get -qq install -y build-essential python3 splint gcc gdb gcc-arm-none-eabi gcc-powerpc-linux-gnu qemu-system-ppc texinfo xvfb pandoc wkhtmltopdf wget libc6-dev-powerpc-cross ipxe-qemu
 
 if ! python${PY_VER} --version; then
     sudo apt-get install -y python${PY_VER}

--- a/test_setup.sh
+++ b/test_setup.sh
@@ -50,7 +50,10 @@ sudo apt-get -qq install software-properties-common
 sudo add-apt-repository -y ppa:jonathonf/python-3.6
 sudo apt-get -qq update
 sudo apt-get -qq install -y build-essential python3 splint gcc gdb gcc-arm-none-eabi gcc-powerpc-linux-gnu qemu-system-ppc texinfo xvfb pandoc wkhtmltopdf wget
-which python${PY_VER} || sudo apt-get install -y python${PY_VER}
+
+if ! python${PY_VER} --version; then
+    sudo apt-get install -y python${PY_VER}
+fi
 
 # gdb-arm-none-eabi: required for testing ARM systems.
 # The diversion is required due to an Ubuntu package bug that has been patched but may be present in some systems.

--- a/test_setup.sh
+++ b/test_setup.sh
@@ -46,6 +46,7 @@ fi
 # texinfo: required for installing gdb from source
 # xvfb pandoc wkhtmltopdf: required for building documentation
 # python3.5, python3.6: currently not available in default Travis CI environment
+sudo apt-get -qq install software-properties-common
 sudo add-apt-repository -y ppa:jonathonf/python-3.6
 sudo apt-get -qq update
 sudo apt-get -qq install -y build-essential python3 splint gcc gdb gcc-arm-none-eabi gcc-powerpc-linux-gnu qemu-system-ppc texinfo xvfb pandoc wkhtmltopdf

--- a/test_setup.sh
+++ b/test_setup.sh
@@ -49,7 +49,7 @@ fi
 sudo apt-get -qq install software-properties-common
 sudo add-apt-repository -y ppa:jonathonf/python-3.6
 sudo apt-get -qq update
-sudo apt-get -qq install -y build-essential python3 splint gcc gdb gcc-arm-none-eabi gcc-powerpc-linux-gnu qemu-system-ppc texinfo xvfb pandoc wkhtmltopdf
+sudo apt-get -qq install -y build-essential python3 splint gcc gdb gcc-arm-none-eabi gcc-powerpc-linux-gnu qemu-system-ppc texinfo xvfb pandoc wkhtmltopdf wget
 which python${PY_VER} || sudo apt-get install -y python${PY_VER}
 
 # gdb-arm-none-eabi: required for testing ARM systems.


### PR DESCRIPTION
# Motivation

The RTOS is currently being tested on Ubuntu 14.04 via TravisCI.
This is in itself a relatively outdated operating system version.
It also makes tests against Python 3.7 more difficult than necessary.

# Goals

The primary goal of this PR is to run regression tests on a newer Linux distribution version.
The intended approach is to update the TravisCI configuration to use the most recent available Ubuntu version on TravisCI.
This may require further adjustments in the test setup and the tests themselves.

# Release Impact: Patch

# Test Plan

- Please review code changes to ensure that they meet the goals of this task and comply with conventions
- Please verify that all regression tests still pass